### PR TITLE
fix dead link

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,4 +494,4 @@ Biel Artigues Aguilo, Francesc Vilardell Sallés
 
 IEEC website: http://www.ieec.cat/
 
-ICE telescope website: https://www.ice.csic.es/en/content/85/astroearth-laboratory
+ICE telescope website: https://dev.ice.csic.es/en/content/85/astroearth-laboratory

--- a/README.md
+++ b/README.md
@@ -494,4 +494,4 @@ Biel Artigues Aguilo, Francesc Vilardell Sallés
 
 IEEC website: http://www.ieec.cat/
 
-ICE telescope website: https://dev.ice.csic.es/en/content/85/astroearth-laboratory
+ICE telescope website: https://www.ice.csic.es/technology/labs


### PR DESCRIPTION
"ICE telescope website" link at bottom changed from "http://www..." to "https://dev..." which is likely the intended site. The current link 404's.